### PR TITLE
🐛  fix: remove slash when has a route greater than 1 length and ends with slash

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,9 @@ func New(config ...Config) fiber.Handler {
 
 // https://github.com/labstack/echo/blob/master/middleware/rewrite.go
 func captureTokens(pattern *regexp.Regexp, input string) *strings.Replacer {
+	if len(input) > 1 {
+		input = strings.TrimSuffix(input, "/")
+	}
 	groups := pattern.FindAllStringSubmatch(input, -1)
 	if groups == nil {
 		return nil

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,17 @@ func Test_Redirect(t *testing.T) {
 		StatusCode: 302,
 	}))
 
+	app.Use(New(Config{
+		Rules: map[string]string{
+			"/": "/swagger",
+		},
+		StatusCode: 301,
+	}))
+
+	app.Get("/api/*", func(c *fiber.Ctx) error {
+		return c.SendString("API")
+	})
+
 	app.Get("/new", func(c *fiber.Ctx) error {
 		return c.SendString("Hello, World!")
 	})
@@ -76,6 +87,22 @@ func Test_Redirect(t *testing.T) {
 		{
 			name:       "access URL without rule",
 			url:        "/new",
+			statusCode: 200,
+		},
+		{
+			name:       "redirect to swagger route",
+			url:        "/",
+			redirectTo: "/swagger",
+			statusCode: 301,
+		},
+		{
+			name:       "no redirect to swagger route",
+			url:        "/api/",
+			statusCode: 200,
+		},
+		{
+			name:       "no redirect to swagger route #2",
+			url:        "/api/test",
 			statusCode: 200,
 		},
 	}


### PR DESCRIPTION
reference issue: https://github.com/gofiber/fiber/issues/997
